### PR TITLE
Set X-Forwarded-Proto header to HTTPS

### DIFF
--- a/etc/nginx/conf.d/jenkins.conf
+++ b/etc/nginx/conf.d/jenkins.conf
@@ -11,7 +11,7 @@ server {
         proxy_set_header   Host             $host;
         proxy_set_header   X-Real-IP        $remote_addr;
         proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-	    proxy_set_header   X-Forwarded-Proto http;
+        proxy_set_header   X-Forwarded-Proto https;
         proxy_max_temp_file_size 0;
 
         proxy_connect_timeout      150;


### PR DESCRIPTION
otherwise Jenkins complains about misconfigured reverse proxy